### PR TITLE
[Refactor] 공유 기능 리팩토링

### DIFF
--- a/presentation/src/main/java/team/jsv/icec/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/MainActivity.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 import team.jsv.icec.base.BaseActivity
 import team.jsv.icec.base.startActivityWithAnimation
 import team.jsv.icec.ui.main.mosaic.result.MosaicResultActivity
-import team.jsv.icec.util.Extras.ImagePath
+import team.jsv.icec.util.Extras.ResultImageKey
 import team.jsv.icec.util.gone
 import team.jsv.icec.util.loadImage
 import team.jsv.icec.util.saveImage
@@ -119,9 +119,10 @@ class MainActivity :
                     }
 
                     MainEvent.NavigateToMosaicResult -> {
-                        saveImage(bitmap = binding.ivImage.toBitmap())
-                        // TODO(ham2174) : 이미지 경로 넘겨주기. (이미지 경로 saveImage 함수에서 )
-                        startActivityWithAnimation<MosaicResultActivity>()
+                        val mosaicImageUri = saveImage(bitmap = binding.ivImage.toBitmap()).toString()
+                        startActivityWithAnimation<MosaicResultActivity>(
+                            intentBuilder = { putExtra(ResultImageKey, mosaicImageUri)}
+                        )
                         finish()
                     }
 

--- a/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultActivity.kt
@@ -7,7 +7,6 @@ import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import team.jsv.icec.base.BaseActivity
-import team.jsv.icec.util.gone
 import team.jsv.icec.util.loadImage
 import team.jsv.icec.util.showSnackBarAction
 import team.jsv.icec.util.visible
@@ -30,15 +29,7 @@ class MosaicResultActivity :
     override fun onResume() {
         super.onResume()
 
-        binding.topBar.ivShare.isEnabled = true
-
         initClickListeners()
-    }
-
-    override fun onPause() {
-        super.onPause()
-
-        binding.topBar.ivShare.isEnabled = false
     }
 
     private fun initTopBar() {
@@ -60,7 +51,7 @@ class MosaicResultActivity :
         lifecycleScope.launch {
             viewModel.mosaicResultEvent.collect { event ->
                 when(event) {
-                    is MosaicResultEvent.FinishActivity -> { finish() }
+                    MosaicResultEvent.FinishActivity -> { finish() }
 
                     is MosaicResultEvent.SendMosaicImage -> {
                         val shareIntent = Intent().apply {
@@ -71,6 +62,8 @@ class MosaicResultActivity :
 
                         startActivity(Intent.createChooser(shareIntent, getString(R.string.share_text)))
                     }
+
+                    else -> {}
                 }
             }
         }
@@ -78,11 +71,11 @@ class MosaicResultActivity :
 
     private fun initClickListeners() {
         binding.topBar.ivShare.setOnClickListener {
-            viewModel.handleMosaicResultEvent(MosaicResultEvent.Event.Share)
+            viewModel.handleMosaicResultEvent(MosaicResultEvent.Share)
         }
 
         binding.topBar.btClose.setOnClickListener {
-            viewModel.handleMosaicResultEvent(MosaicResultEvent.Event.ActivityFinish)
+            viewModel.handleMosaicResultEvent(MosaicResultEvent.FinishActivity)
         }
     }
 

--- a/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultActivity.kt
@@ -51,9 +51,9 @@ class MosaicResultActivity :
         lifecycleScope.launch {
             viewModel.mosaicResultEvent.collect { event ->
                 when(event) {
-                    MosaicResultEvent.FinishActivity -> { finish() }
+                    MosaicResultEvent.OnClickFinish -> { finish() }
 
-                    is MosaicResultEvent.SendMosaicImage -> {
+                    is MosaicResultEvent.OnClickShare -> {
                         val shareIntent = Intent().apply {
                             action = Intent.ACTION_SEND
                             putExtra(Intent.EXTRA_STREAM,event.mosaicImage.toUri())
@@ -62,8 +62,6 @@ class MosaicResultActivity :
 
                         startActivity(Intent.createChooser(shareIntent, getString(R.string.share_text)))
                     }
-
-                    else -> {}
                 }
             }
         }
@@ -71,11 +69,11 @@ class MosaicResultActivity :
 
     private fun initClickListeners() {
         binding.topBar.ivShare.setOnClickListener {
-            viewModel.handleMosaicResultEvent(MosaicResultEvent.Share)
+            viewModel.setOnClickShare()
         }
 
         binding.topBar.btClose.setOnClickListener {
-            viewModel.handleMosaicResultEvent(MosaicResultEvent.FinishActivity)
+            viewModel.setOnClickClose()
         }
     }
 

--- a/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultEvent.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultEvent.kt
@@ -2,10 +2,7 @@ package team.jsv.icec.ui.main.mosaic.result
 
 sealed class MosaicResultEvent {
 
-    enum class Event {
-        Share,
-        ActivityFinish;
-    }
+    object Share : MosaicResultEvent()
 
     object FinishActivity : MosaicResultEvent()
 

--- a/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultEvent.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultEvent.kt
@@ -1,0 +1,14 @@
+package team.jsv.icec.ui.main.mosaic.result
+
+sealed class MosaicResultEvent {
+
+    enum class Event {
+        Share,
+        ActivityFinish;
+    }
+
+    object FinishActivity : MosaicResultEvent()
+
+    class SendMosaicImage(val mosaicImage: String) : MosaicResultEvent()
+
+}

--- a/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultEvent.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultEvent.kt
@@ -2,10 +2,8 @@ package team.jsv.icec.ui.main.mosaic.result
 
 sealed class MosaicResultEvent {
 
-    object Share : MosaicResultEvent()
+    object OnClickFinish : MosaicResultEvent()
 
-    object FinishActivity : MosaicResultEvent()
-
-    class SendMosaicImage(val mosaicImage: String) : MosaicResultEvent()
+    class OnClickShare(val mosaicImage: String) : MosaicResultEvent()
 
 }

--- a/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultViewModel.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultViewModel.kt
@@ -6,28 +6,42 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import team.jsv.icec.base.BaseViewModel
 import team.jsv.icec.util.Extras.ResultImageKey
+import team.jsv.util_kotlin.MutableDebounceFlow
+import team.jsv.util_kotlin.debounceAction
 
 class MosaicResultViewModel(savedStateHandle: SavedStateHandle) : BaseViewModel() {
 
     private val _image = MutableStateFlow(savedStateHandle.get<String>(ResultImageKey) ?: "")
-    val image: StateFlow<String> get() = _image
+    val image: StateFlow<String> = _image.asStateFlow()
 
     private val _mosaicResultEvent = MutableSharedFlow<MosaicResultEvent>()
     val mosaicResultEvent = _mosaicResultEvent.asSharedFlow()
 
-    fun handleMosaicResultEvent(event: MosaicResultEvent.Event) {
+    private val _debounceShareEvent = MutableDebounceFlow<String> {
+        debounceAction(
+            coroutineScope = viewModelScope,
+            timeoutMillis = 200
+        ) { mosaicImage ->
+            _mosaicResultEvent.emit(MosaicResultEvent.SendMosaicImage(mosaicImage = mosaicImage))
+        }
+    }
+
+    fun handleMosaicResultEvent(event: MosaicResultEvent) {
         viewModelScope.launch {
             when (event) {
-                MosaicResultEvent.Event.Share -> {
-                    _mosaicResultEvent.emit(MosaicResultEvent.SendMosaicImage(_image.value))
+                MosaicResultEvent.Share -> {
+                    _debounceShareEvent.emit(_image.value)
                 }
 
-                MosaicResultEvent.Event.ActivityFinish -> {
+                MosaicResultEvent.FinishActivity -> {
                     _mosaicResultEvent.emit(MosaicResultEvent.FinishActivity)
                 }
+
+                else -> {}
             }
         }
     }

--- a/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultViewModel.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultViewModel.kt
@@ -1,16 +1,35 @@
 package team.jsv.icec.ui.main.mosaic.result
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import team.jsv.icec.base.BaseViewModel
+import team.jsv.icec.util.Extras.ResultImageKey
 
-class MosaicResultViewModel : BaseViewModel() {
+class MosaicResultViewModel(savedStateHandle: SavedStateHandle) : BaseViewModel() {
 
-    private val _image = MutableLiveData<String>()
-    val image: LiveData<String> get() = _image
+    private val _image = MutableStateFlow(savedStateHandle.get<String>(ResultImageKey) ?: "")
+    val image: StateFlow<String> get() = _image
 
-    fun setImage(image: String) {
-        _image.value = image
+    private val _mosaicResultEvent = MutableSharedFlow<MosaicResultEvent>()
+    val mosaicResultEvent = _mosaicResultEvent.asSharedFlow()
+
+    fun handleMosaicResultEvent(event: MosaicResultEvent.Event) {
+        viewModelScope.launch {
+            when (event) {
+                MosaicResultEvent.Event.Share -> {
+                    _mosaicResultEvent.emit(MosaicResultEvent.SendMosaicImage(_image.value))
+                }
+
+                MosaicResultEvent.Event.ActivityFinish -> {
+                    _mosaicResultEvent.emit(MosaicResultEvent.FinishActivity)
+                }
+            }
+        }
     }
 
 }

--- a/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultViewModel.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultViewModel.kt
@@ -26,23 +26,19 @@ class MosaicResultViewModel(savedStateHandle: SavedStateHandle) : BaseViewModel(
             coroutineScope = viewModelScope,
             timeoutMillis = 200
         ) { mosaicImage ->
-            _mosaicResultEvent.emit(MosaicResultEvent.SendMosaicImage(mosaicImage = mosaicImage))
+            _mosaicResultEvent.emit(MosaicResultEvent.OnClickShare(mosaicImage = mosaicImage))
         }
     }
 
-    fun handleMosaicResultEvent(event: MosaicResultEvent) {
+    fun setOnClickShare() {
         viewModelScope.launch {
-            when (event) {
-                MosaicResultEvent.Share -> {
-                    _debounceShareEvent.emit(_image.value)
-                }
+            _debounceShareEvent.emit(_image.value)
+        }
+    }
 
-                MosaicResultEvent.FinishActivity -> {
-                    _mosaicResultEvent.emit(MosaicResultEvent.FinishActivity)
-                }
-
-                else -> {}
-            }
+    fun setOnClickClose() {
+        viewModelScope.launch {
+            _mosaicResultEvent.emit(MosaicResultEvent.OnClickFinish)
         }
     }
 


### PR DESCRIPTION
### OvewView

- `MosaicResultEvent`가 추가되었습니다.
- 모자이크된 이미지를 인텐트에 담아 보내주는 로직이 추가되었습니다.
- `LiveData`를 사용한 옵저버 패턴에서 `Flow`를 사용한 단방향 데이터 흐름 패턴으로 변경되었습니다.

### KeyPoint

- `onPause()`와 `onResume()`에  각각 공유 버튼에 대한 `isEnabled` 설정을 해주었습니다. 해당 설정은 사용자가 연속으로 공유 버튼을 누를 시 `공유 화면`이 여러번 나오는것을 방지합니다.