### PR TITLE
CameraView 상태바, 이미지 사이즈 이슈 해결

### DIFF
--- a/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
@@ -11,11 +11,4 @@ class CameraActivity : BaseActivity<ActivityCameraBinding>(R.layout.activity_cam
         super.onWindowFocusChanged(hasFocus)
         hideSystemUI(binding.cameraNavHostFragment)
     }
-
-    companion object {
-        const val RESOURCE_STATUS_NAME = "status_bar_height"
-        const val RESOURCE_NAVIGATION_NAME = "navigation_bar_height"
-        const val RESOURCE_DEF_TYPE = "dimen"
-        const val RESOURCE_DEF_PACKAGE = "android"
-    }
 }

--- a/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
@@ -1,19 +1,11 @@
 package team.jsv.icec.ui.camera
 
-import android.os.Bundle
 import team.jsv.icec.base.BaseActivity
-import team.jsv.icec.util.PermissionUtil
 import team.jsv.icec.util.hideSystemUI
-import team.jsv.icec.util.requestPermissions
 import team.jsv.presentation.R
 import team.jsv.presentation.databinding.ActivityCameraBinding
 
 class CameraActivity : BaseActivity<ActivityCameraBinding>(R.layout.activity_camera) {
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        requestPermissions(PermissionUtil.getPermissions())
-    }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)

--- a/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
@@ -1,8 +1,14 @@
 package team.jsv.icec.ui.camera
 
+import android.os.Build
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowInsets
 import team.jsv.icec.base.BaseActivity
 import team.jsv.icec.util.PermissionUtil
+import team.jsv.icec.util.SettingViewUtil
 import team.jsv.icec.util.requestPermissions
 import team.jsv.presentation.R
 import team.jsv.presentation.databinding.ActivityCameraBinding
@@ -12,5 +18,10 @@ class CameraActivity : BaseActivity<ActivityCameraBinding>(R.layout.activity_cam
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         requestPermissions(PermissionUtil.getPermissions())
+    companion object {
+        const val RESOURCE_STATUS_NAME = "status_bar_height"
+        const val RESOURCE_NAVIGATION_NAME = "navigation_bar_height"
+        const val RESOURCE_DEF_TYPE = "dimen"
+        const val RESOURCE_DEF_PACKAGE = "android"
     }
 }

--- a/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
@@ -1,14 +1,9 @@
 package team.jsv.icec.ui.camera
 
-import android.os.Build
-import android.os.Build.VERSION_CODES
 import android.os.Bundle
-import android.view.View
-import android.view.ViewGroup
-import android.view.WindowInsets
 import team.jsv.icec.base.BaseActivity
 import team.jsv.icec.util.PermissionUtil
-import team.jsv.icec.util.SettingViewUtil
+import team.jsv.icec.util.hideSystemUI
 import team.jsv.icec.util.requestPermissions
 import team.jsv.presentation.R
 import team.jsv.presentation.databinding.ActivityCameraBinding
@@ -20,33 +15,9 @@ class CameraActivity : BaseActivity<ActivityCameraBinding>(R.layout.activity_cam
         requestPermissions(PermissionUtil.getPermissions())
     }
 
-
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        hideSystemUI()
-    }
-
-    private fun hideSystemUI() {
-        if (Build.VERSION.SDK_INT >= VERSION_CODES.R) {
-            window.setDecorFitsSystemWindows(false)
-            window.insetsController?.hide(WindowInsets.Type.statusBars())
-            setBottomMargin()
-        } else {
-            window.decorView.systemUiVisibility =
-                (View.SYSTEM_UI_FLAG_FULLSCREEN
-                        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                        or View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
-        }
-    }
-
-    private fun setBottomMargin() {
-        val layoutParams =
-            binding.cameraNavHostFragment.layoutParams as ViewGroup.MarginLayoutParams
-        layoutParams.setMargins(
-            0, 0, 0,
-            SettingViewUtil.getNavigationBarHeightDP(this)
-        )
-        binding.cameraNavHostFragment.layoutParams = layoutParams
+        hideSystemUI(binding.cameraNavHostFragment)
     }
 
     companion object {

--- a/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/camera/CameraActivity.kt
@@ -18,6 +18,37 @@ class CameraActivity : BaseActivity<ActivityCameraBinding>(R.layout.activity_cam
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         requestPermissions(PermissionUtil.getPermissions())
+    }
+
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        hideSystemUI()
+    }
+
+    private fun hideSystemUI() {
+        if (Build.VERSION.SDK_INT >= VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(false)
+            window.insetsController?.hide(WindowInsets.Type.statusBars())
+            setBottomMargin()
+        } else {
+            window.decorView.systemUiVisibility =
+                (View.SYSTEM_UI_FLAG_FULLSCREEN
+                        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        or View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
+        }
+    }
+
+    private fun setBottomMargin() {
+        val layoutParams =
+            binding.cameraNavHostFragment.layoutParams as ViewGroup.MarginLayoutParams
+        layoutParams.setMargins(
+            0, 0, 0,
+            SettingViewUtil.getNavigationBarHeightDP(this)
+        )
+        binding.cameraNavHostFragment.layoutParams = layoutParams
+    }
+
     companion object {
         const val RESOURCE_STATUS_NAME = "status_bar_height"
         const val RESOURCE_NAVIGATION_NAME = "navigation_bar_height"

--- a/presentation/src/main/java/team/jsv/icec/ui/camera/CameraFragment.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/camera/CameraFragment.kt
@@ -234,11 +234,4 @@ class CameraFragment : BaseFragment<FragmentCameraBinding>(R.layout.fragment_cam
             )
         }.build()
     }
-
-    companion object {
-        const val RESOURCE_NAME = "status_bar_height"
-        const val RESOURCE_DEF_TYPE = "dimen"
-        const val RESOURCE_DEF_PACKAGE = "android"
-    }
-
 }

--- a/presentation/src/main/java/team/jsv/icec/ui/camera/CameraFragment.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/camera/CameraFragment.kt
@@ -111,9 +111,9 @@ class CameraFragment : BaseFragment<FragmentCameraBinding>(R.layout.fragment_cam
                 ratioState,
                 this.deviceWidth,
                 this.deviceHeight
-            ).apply {
-                startCamera()
-            }
+            )
+
+            startCamera()
 
             when (ratioState) {
                 SettingRatio.RATIO_1_1.id -> {

--- a/presentation/src/main/java/team/jsv/icec/util/SettingViewUtil.kt
+++ b/presentation/src/main/java/team/jsv/icec/util/SettingViewUtil.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
-import team.jsv.icec.ui.camera.CameraActivity
 import team.jsv.icec.ui.camera.SettingRatio
 import kotlin.math.roundToInt
 
@@ -17,6 +16,11 @@ enum class ConnenctState(val id: Int) {
 }
 
 object SettingViewUtil {
+    private const val RESOURCE_STATUS_NAME = "status_bar_height"
+    private const val RESOURCE_NAVIGATION_NAME = "navigation_bar_height"
+    private const val RESOURCE_DEF_TYPE = "dimen"
+    private const val RESOURCE_DEF_PACKAGE = "android"
+
     fun resizeView(
         layoutParams: ViewGroup.LayoutParams,
         ratioValue: Int,
@@ -116,9 +120,9 @@ object SettingViewUtil {
 
         val resourceId: Int =
             context.resources.getIdentifier(
-                CameraActivity.RESOURCE_STATUS_NAME,
-                CameraActivity.RESOURCE_DEF_TYPE,
-                CameraActivity.RESOURCE_DEF_PACKAGE
+                RESOURCE_STATUS_NAME,
+                RESOURCE_DEF_TYPE,
+                RESOURCE_DEF_PACKAGE
             )
 
         if (resourceId > 0) {
@@ -132,9 +136,9 @@ object SettingViewUtil {
     fun getNavigationBarHeightDP(context: Context): Int {
         var result = 0
         val resourceId = context.resources.getIdentifier(
-            CameraActivity.RESOURCE_NAVIGATION_NAME,
-            CameraActivity.RESOURCE_DEF_TYPE,
-            CameraActivity.RESOURCE_DEF_PACKAGE
+            RESOURCE_NAVIGATION_NAME,
+            RESOURCE_DEF_TYPE,
+            RESOURCE_DEF_PACKAGE
         )
         if (resourceId > 0) {
             result = context.resources.getDimension(resourceId).toInt()

--- a/presentation/src/main/java/team/jsv/icec/util/SettingViewUtil.kt
+++ b/presentation/src/main/java/team/jsv/icec/util/SettingViewUtil.kt
@@ -6,7 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
-import team.jsv.icec.ui.camera.CameraFragment
+import team.jsv.icec.ui.camera.CameraActivity
 import team.jsv.icec.ui.camera.SettingRatio
 import kotlin.math.roundToInt
 
@@ -116,11 +116,26 @@ object SettingViewUtil {
 
         val resourceId: Int =
             context.resources.getIdentifier(
-                CameraFragment.RESOURCE_NAME,
-                CameraFragment.RESOURCE_DEF_TYPE,
-                CameraFragment.RESOURCE_DEF_PACKAGE
+                CameraActivity.RESOURCE_STATUS_NAME,
+                CameraActivity.RESOURCE_DEF_TYPE,
+                CameraActivity.RESOURCE_DEF_PACKAGE
             )
 
+        if (resourceId > 0) {
+            result = context.resources.getDimension(resourceId).toInt()
+        }
+
+        return result
+    }
+
+    @SuppressLint("InternalInsetResource", "DiscouragedApi")
+    fun getNavigationBarHeightDP(context: Context): Int {
+        var result = 0
+        val resourceId = context.resources.getIdentifier(
+            CameraActivity.RESOURCE_NAVIGATION_NAME,
+            CameraActivity.RESOURCE_DEF_TYPE,
+            CameraActivity.RESOURCE_DEF_PACKAGE
+        )
         if (resourceId > 0) {
             result = context.resources.getDimension(resourceId).toInt()
         }

--- a/presentation/src/main/java/team/jsv/icec/util/activityUtils.kt
+++ b/presentation/src/main/java/team/jsv/icec/util/activityUtils.kt
@@ -1,9 +1,12 @@
 package team.jsv.icec.util
 
+import android.app.Activity
 import android.content.Context
 import android.graphics.drawable.GradientDrawable
+import android.os.Build
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowInsets
 import android.widget.TextView
 import android.widget.Toast
 import com.google.android.material.snackbar.Snackbar
@@ -18,6 +21,31 @@ fun View.showSnackBarAction(msg: Int, textColor: Int, backgroundColor: Int) {
     this.initSnackBarSetting(snackBar)
     setSnackBarOption(snackBar, context.getColor(textColor), context.getColor(backgroundColor))
     snackBar.show()
+}
+
+/* root View 를 제공해야합니다 */
+fun Activity.hideSystemUI(view : View) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        window.setDecorFitsSystemWindows(false)
+        window.insetsController?.hide(WindowInsets.Type.statusBars())
+        setBottomMargin(view, this)
+    } else {
+        window.decorView.systemUiVisibility =
+            (View.SYSTEM_UI_FLAG_FULLSCREEN
+                    or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
+    }
+}
+
+private fun setBottomMargin(view : View, context: Context) {
+    val layoutParams =
+        view.layoutParams as ViewGroup.MarginLayoutParams
+    layoutParams.setMargins(
+        0, 0, 0,
+        SettingViewUtil.getNavigationBarHeightDP(context)
+    )
+
+    view.layoutParams = layoutParams
 }
 
 private fun View.initSnackBarSetting(snackBar: Snackbar) {

--- a/presentation/src/main/java/team/jsv/icec/util/activityUtils.kt
+++ b/presentation/src/main/java/team/jsv/icec/util/activityUtils.kt
@@ -30,6 +30,8 @@ fun Activity.hideSystemUI(view : View) {
         window.insetsController?.hide(WindowInsets.Type.statusBars())
         setBottomMargin(view, this)
     } else {
+        @Suppress("DEPRECATION")
+        // API 30 이상에서는 deprecated 됨 @jiiiiiyoon
         window.decorView.systemUiVisibility =
             (View.SYSTEM_UI_FLAG_FULLSCREEN
                     or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN

--- a/presentation/src/main/res/values-night/themes.xml
+++ b/presentation/src/main/res/values-night/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- ICEC.ActivityTheme -->
     <style name="ICECTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
@@ -8,9 +8,7 @@
     </style>
 
     <style name="ICECCameraTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
-        <item name="windowNoTitle">true</item>
-        <item name="android:windowFullscreen">true</item>
-        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:ignore="NewApi">shortEdges</item>
     </style>
 
 </resources>

--- a/presentation/src/main/res/values-night/themes.xml
+++ b/presentation/src/main/res/values-night/themes.xml
@@ -9,6 +9,7 @@
 
     <style name="ICECCameraTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="android:windowLayoutInDisplayCutoutMode" tools:ignore="NewApi">shortEdges</item>
+        <item name="android:statusBarColor">@color/transparent</item>
     </style>
 
 </resources>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- ICEC.ActivityTheme -->
     <style name="ICECTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
@@ -8,9 +8,7 @@
     </style>
 
     <style name="ICECCameraTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
-        <item name="windowNoTitle">true</item>
-        <item name="android:windowFullscreen">true</item>
-        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:ignore="NewApi">shortEdges</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## resolve
#26 #42 

- API 버전에 맞게 상태바의 영역 위에 뷰를 덮고 FULL화면으로 보여지게 함
- navigationBar 만큼의 Bottom 마진을 설정
- apply문에서 startCamera 실행하던 것을 apply문을 제거함으로써 첫번째 이미지가 비율에 맞게 결과 화면으로 넘어감