### PR TITLE
[Refactor] sdk 24~28 공유기능 대응

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="team.jsv.icec">
 
     <application android:theme="@style/ICECTheme">
 
@@ -36,7 +37,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.example.fileprovider"
+            android:authorities="team.jsv.icec.provider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/presentation/src/main/java/team/jsv/icec/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/MainActivity.kt
@@ -121,7 +121,7 @@ class MainActivity :
                     MainEvent.NavigateToMosaicResult -> {
                         val mosaicImageUri = saveImage(bitmap = binding.ivImage.toBitmap()).toString()
                         startActivityWithAnimation<MosaicResultActivity>(
-                            intentBuilder = { putExtra(ResultImageKey, mosaicImageUri)}
+                            intentBuilder = { putExtra(ResultImageKey, mosaicImageUri) }
                         )
                         finish()
                     }

--- a/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/mosaic/result/MosaicResultActivity.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import team.jsv.icec.base.BaseActivity
 import team.jsv.icec.util.loadImage
+import team.jsv.icec.util.shareImage
 import team.jsv.icec.util.showSnackBarAction
 import team.jsv.icec.util.visible
 import team.jsv.presentation.R
@@ -61,28 +62,6 @@ class MosaicResultActivity :
                 }
             }
         }
-    }
-
-    private fun shareImage(mosaicImagePath: String) {
-        val shareIntent = Intent(Intent.ACTION_SEND).apply {
-            type = SHARE_TYPE
-
-            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
-            ) {
-                val contentUri = FileProvider.getUriForFile(
-                    this@MosaicResultActivity,
-                    "${packageName}.provider",
-                    File(URI(mosaicImagePath).path)
-                )
-                putExtra(Intent.EXTRA_STREAM, contentUri)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            } else {
-                putExtra(Intent.EXTRA_STREAM, mosaicImagePath.toUri())
-            }
-        }
-
-        startActivity(Intent.createChooser(shareIntent, getString(R.string.share_text)))
     }
 
     private fun initClickListeners() {

--- a/presentation/src/main/java/team/jsv/icec/util/ContextExtention.kt
+++ b/presentation/src/main/java/team/jsv/icec/util/ContextExtention.kt
@@ -1,0 +1,41 @@
+package team.jsv.icec.util
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.content.FileProvider
+import androidx.core.net.toUri
+import team.jsv.icec.ui.main.mosaic.result.MosaicResultActivity
+import team.jsv.presentation.R
+import java.io.File
+import java.net.URI
+
+/**
+ * [Context] 확장 함수 이미지 공유 기능 입니다.
+ * @param imagePath 공유할 이미지의 content URI
+ * EX) "content://media/external/images/media/1000000150"
+ * @return Unit
+ */
+fun Context.shareImage(
+    contentUri: String
+) {
+    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+        type = MosaicResultActivity.SHARE_TYPE
+
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+        ) {
+            val fileUri = FileProvider.getUriForFile(
+                this@shareImage,
+                "${this@shareImage.packageName}.provider",
+                File(URI(contentUri).path)
+            )
+            putExtra(Intent.EXTRA_STREAM, fileUri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        } else {
+            putExtra(Intent.EXTRA_STREAM, contentUri.toUri())
+        }
+    }
+
+    this.startActivity(Intent.createChooser(shareIntent, this.getString(R.string.share_text)))
+}


### PR DESCRIPTION
### OverView

- sdk 24 ~ 28 까지 `file:// uri` 가 아닌 `content:// uri` 를 사용해야 하므로 해당 부분에 포함되는 sdk는 `content:// uri`를 사용하여 공유할 수 있게 분기처리하여 로직을 수정하였습니다. #48