### PR TITLE
[Refactor] 카메라 기능에서 촬영된 사진 MainActivity로 전달 안되는 이슈 해결

### DIFF
--- a/presentation/src/main/java/team/jsv/icec/ui/camera/CameraResultFragment.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/camera/CameraResultFragment.kt
@@ -1,13 +1,12 @@
 package team.jsv.icec.ui.camera
 
-import android.content.Intent
-import android.util.Log
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import team.jsv.icec.base.BaseFragment
+import team.jsv.icec.base.startActivityWithAnimation
 import team.jsv.icec.ui.main.MainActivity
 import team.jsv.icec.util.ConnenctState
 import team.jsv.icec.util.Extras.ImagePath
@@ -53,11 +52,10 @@ class CameraResultFragment :
                     requireActivity().run {
                         val imageUri = saveImage(bitmap = bitmapImage)
                         val imagePath = getPathFromUri(uri = imageUri)
-                        val intent = Intent(this, MainActivity::class.java).apply {
-                            putExtra(ImagePath, imagePath)
-                        }
-                        startActivity(intent)
-                        finish()
+                        startActivityWithAnimation<MainActivity>(
+                            intentBuilder = { putExtra(ImagePath, imagePath) },
+                            withFinish = true
+                        )
                     }
                 }
             }

--- a/presentation/src/main/java/team/jsv/icec/ui/camera/CameraResultFragment.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/camera/CameraResultFragment.kt
@@ -1,6 +1,7 @@
 package team.jsv.icec.ui.camera
 
 import android.content.Intent
+import android.util.Log
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.fragment.app.activityViewModels
@@ -9,9 +10,11 @@ import kotlinx.coroutines.launch
 import team.jsv.icec.base.BaseFragment
 import team.jsv.icec.ui.main.MainActivity
 import team.jsv.icec.util.ConnenctState
+import team.jsv.icec.util.Extras.ImagePath
 import team.jsv.icec.util.SettingViewUtil
 import team.jsv.icec.util.deviceHeight
 import team.jsv.icec.util.deviceWidth
+import team.jsv.icec.util.getPathFromUri
 import team.jsv.icec.util.saveImage
 import team.jsv.presentation.R
 import team.jsv.presentation.databinding.FragmentCameraResultBinding
@@ -48,8 +51,12 @@ class CameraResultFragment :
             viewModel.bitmapImage.value?.let { bitmapImage ->
                 lifecycleScope.launch {
                     requireActivity().run {
-                        saveImage(bitmapImage)
-                        startActivity(Intent(requireActivity(), MainActivity::class.java))
+                        val imageUri = saveImage(bitmap = bitmapImage)
+                        val imagePath = getPathFromUri(uri = imageUri)
+                        val intent = Intent(this, MainActivity::class.java).apply {
+                            putExtra(ImagePath, imagePath)
+                        }
+                        startActivity(intent)
                         finish()
                     }
                 }

--- a/presentation/src/main/java/team/jsv/icec/ui/main/start/StartActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/start/StartActivity.kt
@@ -1,7 +1,6 @@
 package team.jsv.icec.ui.main.start
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -14,6 +13,7 @@ import team.jsv.icec.ui.camera.CameraActivity
 import team.jsv.icec.ui.main.MainActivity
 import team.jsv.icec.util.Extras
 import team.jsv.icec.util.PermissionUtil
+import team.jsv.icec.util.getPathFromUri
 import team.jsv.icec.util.requestPermissions
 import team.jsv.presentation.R
 import team.jsv.presentation.databinding.ActivityStartBinding
@@ -41,8 +41,7 @@ class StartActivity : BaseActivity<ActivityStartBinding>(R.layout.activity_start
                 if (result.resultCode == Activity.RESULT_OK) {
                     val data: Intent? = result.data
                     val imageUri: Uri? = data?.data
-                    val imagePath: String? =
-                        imageUri?.let { uri -> getPathFromUri(this@StartActivity, uri) }
+                    val imagePath = imageUri?.let { getPathFromUri(it) }
 
                     startActivityWithAnimation<MainActivity>(intentBuilder = {
                         putExtra(Extras.ImagePath, imagePath)
@@ -63,15 +62,6 @@ class StartActivity : BaseActivity<ActivityStartBinding>(R.layout.activity_start
     private fun openGallery() {
         val galleryIntent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
         imagePickerLauncher.launch(galleryIntent)
-    }
-
-    private fun getPathFromUri(context: Context, uri: Uri): String? {
-        val projection = arrayOf(MediaStore.Images.Media.DATA)
-        val cursor = context.contentResolver.query(uri, projection, null, null, null)
-        return cursor?.use {
-            val columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
-            if (cursor.moveToFirst()) cursor.getString(columnIndex) else null
-        }
     }
 
 }

--- a/presentation/src/main/java/team/jsv/icec/util/ContextExtention.kt
+++ b/presentation/src/main/java/team/jsv/icec/util/ContextExtention.kt
@@ -2,7 +2,9 @@ package team.jsv.icec.util
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
+import android.provider.MediaStore
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import team.jsv.icec.ui.main.mosaic.result.MosaicResultActivity
@@ -38,4 +40,19 @@ fun Context.shareImage(
     }
 
     this.startActivity(Intent.createChooser(shareIntent, this.getString(R.string.share_text)))
+}
+
+/**
+ * [Context] 확장 함수 이미지의 절대 경로를 가져오는 함수 입니다.
+ * @param uri 이미지의 content URI
+ * EX) "content://media/external/images/media/1000000150"
+ * @return [String] 이미지의 절대 경로를 반환합니다. null을 반환할 수 있으니 주의하세요.
+ */
+fun Context.getPathFromUri(uri: Uri): String? {
+    val projection = arrayOf(MediaStore.Images.Media.DATA)
+    val cursor = this.contentResolver.query(uri, projection, null, null, null)
+    return cursor?.use {
+        val columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
+        if (cursor.moveToFirst()) cursor.getString(columnIndex) else null
+    }
 }


### PR DESCRIPTION
### OverView #47 

- `Context()` 확장함수 `getPathFromUri(uri: Uri): String?`가 새롭게 생겼습니다.
- `Uri` 타입을 파라미터로 받고 해당 Uri의 절대경로를 반환합니다.

### KeyPoint
- 메인 액티비티에서의 이미지뷰는 `File` 혹은 서버에서 제공되는 `Url(String)` 받아서 이미지를 보여주고 있습니다. `MainViewModel`에서 `init`을 해주었을 때 `SaveStateHandle`을 통해 `String` 타입을 받고 있습니다. 이는 액티비티에서 `ScreenStep`이 `얼굴검출단계`를 가리키고 있을 때 이미지뷰가 `File` 타입으로 받게되어있어 받아온 `String` 타입은 절대경로를 나타내어야 합니다.. 