### PR TITLE
[Refactor] API 29레벨에서 이미지뷰 오류 리팩토링

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true"
         tools:targetApi="33">
     </application>
 


### PR DESCRIPTION
### OverView

- API 29 레벨에서 모든 이미지뷰에 이미지가 적재되지 않는 현상 해결

[참고자료] https://github.com/bumptech/glide/issues/3896