### PR TITLE
[Refactor] `AppCompatActivity.requestPermissions()` inline fun으로 변경

### DIFF
--- a/presentation/src/main/java/team/jsv/icec/ui/main/start/StartActivity.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/start/StartActivity.kt
@@ -22,6 +22,7 @@ import team.jsv.icec.util.PermissionUtil
 import team.jsv.icec.util.getPathFromUri
 import team.jsv.icec.util.requestPermissions
 import team.jsv.icec.util.setICECThemeBottomNavigationColor
+import team.jsv.icec.util.showToast
 import team.jsv.icec.util.toPx
 import team.jsv.presentation.R
 import team.jsv.presentation.databinding.ActivityStartBinding
@@ -42,7 +43,14 @@ class StartActivity : BaseActivity<ActivityStartBinding>(R.layout.activity_start
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        requestPermissions(PermissionUtil.getPermissions())
+        requestPermissions(
+            permission = PermissionUtil.getPermissions(),
+            onPermissionAccepted = { showToast(getString(R.string.accept_permission)) },
+            onPermissionDenied = {
+                showToast(getString(R.string.reject_permission))
+                finish()
+            }
+        )
         setICECThemeBottomNavigationColor()
 
         setImagePickerLauncher()

--- a/presentation/src/main/java/team/jsv/icec/util/PermissionUtil.kt
+++ b/presentation/src/main/java/team/jsv/icec/util/PermissionUtil.kt
@@ -3,11 +3,9 @@ package team.jsv.icec.util
 import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
-import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import team.jsv.presentation.R
 
 object PermissionUtil {
     /**
@@ -31,18 +29,21 @@ object PermissionUtil {
     }
 }
 
-fun AppCompatActivity.requestPermissions(permission: List<String>) {
+inline fun AppCompatActivity.requestPermissions(
+    permission: List<String>,
+    crossinline onPermissionAccepted: () -> Unit,
+    crossinline onPermissionDenied: () -> Unit
+) {
     val requestPermissions = permission.filter {
         ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
     }
-    this.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
-        result.entries.forEach {
-            if (it.value) {
-                showToast(getString(R.string.accept_permission))
+    if(requestPermissions.isNotEmpty()) {
+        this.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
+            if (result.values.all { it }) {
+                onPermissionAccepted()
             } else {
-                showToast(getString(R.string.reject_permission))
-                finish()
+                onPermissionDenied()
             }
-        }
-    }.launch(requestPermissions.toTypedArray())
+        }.launch(requestPermissions.toTypedArray())
+    }
 }


### PR DESCRIPTION
### OverView

- `AppCompatActivity` 확장함수 `requestPermissions()`를 일반 fun에서 inline fun으로 변경되었습니다.