### PR TITLE
[Refactor] 모자이크 2단계 수치 적용

### DIFF
--- a/data/src/main/java/team/jsv/data/api/ICECApi.kt
+++ b/data/src/main/java/team/jsv/data/api/ICECApi.kt
@@ -15,7 +15,7 @@ interface ICECApi {
     @Multipart
     @POST("/faceList")
     suspend fun getDetectedFace(
-        @Part("currentTime") currentTime: String,
+        @Part("randomSeed") randomSeed: String,
         @Part("threshold") threshold: Float,
         @Part image: MultipartBody.Part,
     ): FaceResponse

--- a/data/src/main/java/team/jsv/data/datasource/ImageDataSource.kt
+++ b/data/src/main/java/team/jsv/data/datasource/ImageDataSource.kt
@@ -15,13 +15,13 @@ class ImageDataSource @Inject constructor(
 ) {
 
     suspend fun getDetectedFace(
-        currentTime: String,
+        randomSeed: String,
         threshold: Float,
         image: File
     ): FaceResponse {
         try {
             return icecApi.getDetectedFace(
-                currentTime = currentTime,
+                randomSeed = randomSeed,
                 threshold =  threshold,
                 image = image.toMultipartImage()
             )
@@ -34,7 +34,7 @@ class ImageDataSource @Inject constructor(
     }
 
     suspend fun getMosaicImage(
-        currentTime: String,
+        randomSeed: String,
         pixelSize: Int,
         originalImage: String,
         coordinates: List<List<Int>>,
@@ -42,7 +42,7 @@ class ImageDataSource @Inject constructor(
         try {
             return icecApi.getMosaicImage(
                 mosaicRequestBody = MosaicRequestBody(
-                    currentTime = currentTime,
+                    randomSeed = randomSeed,
                     pixelSize = pixelSize,
                     originalImage = originalImage,
                     coordinates = coordinates
@@ -57,7 +57,7 @@ class ImageDataSource @Inject constructor(
     }
 
     suspend fun getBlurImage(
-        currentTime: String,
+        randomSeed: String,
         pixelSize: Int,
         originalImage: String,
         coordinates: List<List<Int>>,
@@ -65,7 +65,7 @@ class ImageDataSource @Inject constructor(
         try {
             return icecApi.getBlurImage(
                 mosaicRequestBody = MosaicRequestBody(
-                    currentTime = currentTime,
+                    randomSeed = randomSeed,
                     pixelSize = pixelSize,
                     originalImage = originalImage,
                     coordinates = coordinates

--- a/data/src/main/java/team/jsv/data/dto/request/MosaicRequestBody.kt
+++ b/data/src/main/java/team/jsv/data/dto/request/MosaicRequestBody.kt
@@ -3,7 +3,7 @@ package team.jsv.data.dto.request
 import com.google.gson.annotations.SerializedName
 
 data class MosaicRequestBody(
-    @SerializedName("currentTime") val currentTime: String,
+    @SerializedName("randomSeed") val randomSeed: String,
     @SerializedName("pixelSize") val pixelSize: Int,
     @SerializedName("originalImage") val originalImage: String,
     @SerializedName("coordinates") val coordinates: List<List<Int>>

--- a/data/src/main/java/team/jsv/data/repositoryImpl/ImageRepositoryImpl.kt
+++ b/data/src/main/java/team/jsv/data/repositoryImpl/ImageRepositoryImpl.kt
@@ -13,25 +13,25 @@ class ImageRepositoryImpl @Inject constructor(
 ) : ImageRepository {
 
     override suspend fun getDetectedFace(
-        currentTime: String,
+        randomSeed: String,
         threshold: Float,
         image: File
     ): Face {
         return imageDataSource.getDetectedFace(
-            currentTime = currentTime,
+            randomSeed = randomSeed,
             threshold = threshold,
             image = image
         ).toDomain()
     }
 
     override suspend fun getMosaicImage(
-        currentTime: String,
+        randomSeed: String,
         pixelSize: Int,
         originalImage: String,
         coordinates: List<List<Int>>,
     ): MosaicImage {
         return imageDataSource.getMosaicImage(
-            currentTime = currentTime,
+            randomSeed = randomSeed,
             pixelSize = pixelSize,
             originalImage = originalImage,
             coordinates = coordinates
@@ -39,13 +39,13 @@ class ImageRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getBlurImage(
-        currentTime: String,
+        randomSeed: String,
         pixelSize: Int,
         originalImage: String,
         coordinates: List<List<Int>>,
     ): MosaicImage {
         return imageDataSource.getBlurImage(
-            currentTime = currentTime,
+            randomSeed = randomSeed,
             pixelSize = pixelSize,
             originalImage = originalImage,
             coordinates = coordinates

--- a/domain/src/main/java/team/jsv/domain/repository/ImageRepository.kt
+++ b/domain/src/main/java/team/jsv/domain/repository/ImageRepository.kt
@@ -7,20 +7,20 @@ import java.io.File
 interface ImageRepository {
 
     suspend fun getDetectedFace(
-        currentTime: String,
+        randomSeed: String,
         threshold: Float,
         image: File
     ): Face
 
     suspend fun getMosaicImage(
-        currentTime: String,
+        randomSeed: String,
         pixelSize: Int,
         originalImage: String,
         coordinates: List<List<Int>>,
     ): MosaicImage
 
     suspend fun getBlurImage(
-        currentTime: String,
+        randomSeed: String,
         pixelSize: Int,
         originalImage: String,
         coordinates: List<List<Int>>,

--- a/domain/src/main/java/team/jsv/domain/usecase/GetDetectedFaceUseCase.kt
+++ b/domain/src/main/java/team/jsv/domain/usecase/GetDetectedFaceUseCase.kt
@@ -8,12 +8,12 @@ class GetDetectedFaceUseCase @Inject constructor(
     private val repository: ImageRepository
 ) {
     suspend operator fun invoke(
-        currentTime: String,
+        randomSeed: String,
         threshold: Float,
         image: File
     ) = runCatching {
         repository.getDetectedFace(
-            currentTime = currentTime,
+            randomSeed = randomSeed,
             threshold = threshold,
             image = image
         )

--- a/domain/src/main/java/team/jsv/domain/usecase/GetDetectedFaceUseCase.kt
+++ b/domain/src/main/java/team/jsv/domain/usecase/GetDetectedFaceUseCase.kt
@@ -2,18 +2,18 @@ package team.jsv.domain.usecase
 
 import team.jsv.domain.repository.ImageRepository
 import java.io.File
+import java.util.UUID
 import javax.inject.Inject
 
 class GetDetectedFaceUseCase @Inject constructor(
     private val repository: ImageRepository
 ) {
     suspend operator fun invoke(
-        randomSeed: String,
         threshold: Float,
         image: File
     ) = runCatching {
         repository.getDetectedFace(
-            randomSeed = randomSeed,
+            randomSeed = UUID.randomUUID().toString(),
             threshold = threshold,
             image = image
         )

--- a/domain/src/main/java/team/jsv/domain/usecase/GetMosaicImageUseCase.kt
+++ b/domain/src/main/java/team/jsv/domain/usecase/GetMosaicImageUseCase.kt
@@ -2,13 +2,13 @@ package team.jsv.domain.usecase
 
 import team.jsv.domain.model.MosaicType
 import team.jsv.domain.repository.ImageRepository
+import java.util.UUID
 import javax.inject.Inject
 
 class GetMosaicImageUseCase @Inject constructor(
     private val repository: ImageRepository,
 ) {
     suspend operator fun invoke(
-        randomSeed: String,
         pixelSize: Int,
         originalImage: String,
         coordinates: List<List<Int>>,
@@ -16,13 +16,13 @@ class GetMosaicImageUseCase @Inject constructor(
     ) = runCatching {
         when (mosaicType) {
             MosaicType.Mosaic -> repository.getMosaicImage(
-                randomSeed = randomSeed,
+                randomSeed = UUID.randomUUID().toString(),
                 pixelSize = pixelSize,
                 originalImage = originalImage,
                 coordinates = coordinates
             )
             MosaicType.Blur -> repository.getBlurImage(
-                randomSeed = randomSeed,
+                randomSeed = UUID.randomUUID().toString(),
                 pixelSize = pixelSize / 10,
                 originalImage = originalImage,
                 coordinates = coordinates

--- a/domain/src/main/java/team/jsv/domain/usecase/GetMosaicImageUseCase.kt
+++ b/domain/src/main/java/team/jsv/domain/usecase/GetMosaicImageUseCase.kt
@@ -8,7 +8,7 @@ class GetMosaicImageUseCase @Inject constructor(
     private val repository: ImageRepository,
 ) {
     suspend operator fun invoke(
-        currentTime: String,
+        randomSeed: String,
         pixelSize: Int,
         originalImage: String,
         coordinates: List<List<Int>>,
@@ -16,13 +16,13 @@ class GetMosaicImageUseCase @Inject constructor(
     ) = runCatching {
         when (mosaicType) {
             MosaicType.Mosaic -> repository.getMosaicImage(
-                currentTime = currentTime,
+                randomSeed = randomSeed,
                 pixelSize = pixelSize,
                 originalImage = originalImage,
                 coordinates = coordinates
             )
             MosaicType.Blur -> repository.getBlurImage(
-                currentTime = currentTime,
+                randomSeed = randomSeed,
                 pixelSize = pixelSize / 10,
                 originalImage = originalImage,
                 coordinates = coordinates

--- a/presentation/src/main/java/team/jsv/icec/ui/main/MainViewModel.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/MainViewModel.kt
@@ -24,9 +24,8 @@ import team.jsv.icec.util.Extras
 import team.jsv.icec.util.toThreshold
 import team.jsv.util_kotlin.IcecNetworkException
 import team.jsv.util_kotlin.copy
-import team.jsv.util_kotlin.toFormatString
 import java.io.File
-import java.util.Date
+import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,7 +35,8 @@ internal class MainViewModel @Inject constructor(
     private val getMosaicImageUseCase: GetMosaicImageUseCase,
 ) : BaseViewModel() {
 
-    private val currentTime: String = Date().toFormatString(DEFAULT_CURRENT_TIME_FORMAT)
+    private val randomSeed: String
+        get() = UUID.randomUUID().toString()
 
     //메인 액티비티 상태
     private val _mainState = MutableStateFlow(MainState())
@@ -176,7 +176,7 @@ internal class MainViewModel @Inject constructor(
             setOnClearDetectedFaceIndex()
             with(_detectFaceState.value) {
                 getDetectedFaceUseCase(
-                    currentTime = currentTime,
+                    randomSeed = randomSeed,
                     threshold = detectStrength.toThreshold,
                     image = _mainState.value.pictureState.originalImage
                 ).onSuccess { data ->
@@ -200,7 +200,7 @@ internal class MainViewModel @Inject constructor(
                     .ifEmpty { listOf(listOf()) }
             with(_mosaicFaceState.value) {
                 getMosaicImageUseCase(
-                    currentTime = currentTime,
+                    randomSeed = randomSeed,
                     pixelSize = pixelSize.toInt(),
                     originalImage = originalImage,
                     coordinates = coordinates,

--- a/presentation/src/main/java/team/jsv/icec/ui/main/MainViewModel.kt
+++ b/presentation/src/main/java/team/jsv/icec/ui/main/MainViewModel.kt
@@ -25,7 +25,6 @@ import team.jsv.icec.util.toThreshold
 import team.jsv.util_kotlin.IcecNetworkException
 import team.jsv.util_kotlin.copy
 import java.io.File
-import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
@@ -34,9 +33,6 @@ internal class MainViewModel @Inject constructor(
     private val getDetectedFaceUseCase: GetDetectedFaceUseCase,
     private val getMosaicImageUseCase: GetMosaicImageUseCase,
 ) : BaseViewModel() {
-
-    private val randomSeed: String
-        get() = UUID.randomUUID().toString()
 
     //메인 액티비티 상태
     private val _mainState = MutableStateFlow(MainState())
@@ -176,7 +172,6 @@ internal class MainViewModel @Inject constructor(
             setOnClearDetectedFaceIndex()
             with(_detectFaceState.value) {
                 getDetectedFaceUseCase(
-                    randomSeed = randomSeed,
                     threshold = detectStrength.toThreshold,
                     image = _mainState.value.pictureState.originalImage
                 ).onSuccess { data ->
@@ -200,7 +195,6 @@ internal class MainViewModel @Inject constructor(
                     .ifEmpty { listOf(listOf()) }
             with(_mosaicFaceState.value) {
                 getMosaicImageUseCase(
-                    randomSeed = randomSeed,
                     pixelSize = pixelSize.toInt(),
                     originalImage = originalImage,
                     coordinates = coordinates,
@@ -210,7 +204,7 @@ internal class MainViewModel @Inject constructor(
                         copy(
                             pictureState = pictureState.copy(
                                 viewType = PictureState.ViewType.Mosaic,
-                                mosaicImage = it.mosaicImage, //이녀석이 다른 url로 늘 내려와야 한다
+                                mosaicImage = it.mosaicImage,
                             )
                         )
                     }
@@ -253,10 +247,6 @@ internal class MainViewModel @Inject constructor(
                 _mainEvent.emit(MainEvent.SendToast(exception.message))
             }
         }
-    }
-
-    companion object {
-        private const val DEFAULT_CURRENT_TIME_FORMAT = "yyyy-MM-dd-HHmmss"
     }
 
 }


### PR DESCRIPTION
### OverView

- `getMosaicImage`, `getBlurImage` API에 사용되는 DTO중 `currentTime` 을 `randomSeed`로 변경하였습니다.
- 변경되기 전, 모자이크 수치를 조정할때마다 동일한 사진이 반복되어 모자이크 수치가 올바르게 적용되지 않은 사진이 출력되었습니다. 해당 이슈는 `Flow`에서 발생되는 이슈로 모자이크 이미지 URL을 서버로부터 받았을때, 모자이크 수치가 바뀔때마다 URL 값이 달라져야 화면에 올바르게 출력이 되지만, 기존 방식에선 URL의 값이 유동적이지않고 고정된 값(최초 서버로 Request 날렸을때의 시간)을 주고 있었습니다. 이로 인해 수치가 조정된 사진이 화면에 정상적으로 출력되지 않고 동일한 사진만이 반복적으로 출력되고 있었습니다. 이 이슈는 `randomSeed`라는 `랜덤 UUID`로 해결되었습니다.